### PR TITLE
Minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ No modules.
 | <a name="input_enable_internet_gateway"></a> [enable\_internet\_gateway](#input\_enable\_internet\_gateway) | Enable internet gateway for VPC. | `bool` | `false` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Enable nat gateway for VPC. | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region to provision resources. | `string` | n/a | yes |
-| <a name="input_subnet_cidr_private"></a> [subnet\_cidr\_private](#input\_subnet\_cidr\_private) | CIDR blocks for the private subnets. | `list(any)` | <pre>[<br/>  "10.20.30.0/27",<br/>  "10.20.30.32/27",<br/>  "10.20.30.64/27",<br/>  "10.20.30.96/27"<br/>]</pre> | no |
-| <a name="input_subnet_cidr_public"></a> [subnet\_cidr\_public](#input\_subnet\_cidr\_public) | CIDR blocks for the public subnets. | `list(any)` | <pre>[<br/>  "10.20.30.128/27",<br/>  "10.20.30.160/27",<br/>  "10.20.30.192/27",<br/>  "10.20.30.224/27"<br/>]</pre> | no |
-| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR for the VPC. | `string` | `"10.20.30.0/24"` | no |
+| <a name="input_subnet_cidr_private"></a> [subnet\_cidr\_private](#input\_subnet\_cidr\_private) | CIDR blocks for the private subnets. | `list(any)` | `[]` | no |
+| <a name="input_subnet_cidr_public"></a> [subnet\_cidr\_public](#input\_subnet\_cidr\_public) | CIDR blocks for the public subnets. | `list(any)` | `[]` | no |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR for the VPC. | `string` | `""` | no |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of the VPC. | `string` | `""` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -104,8 +104,14 @@ To use this module in your Terraform configuration, include the following module
 
 ```hcl
 module "vpc" {
-  source = "github.com/kunduso/terraform-aws-vpc?ref=v1.0.0"
-  region = var.region
+  source                  = "github.com/kunduso/terraform-aws-vpc?ref=v1.0.2"
+  region                  = var.region
+  enable_internet_gateway = true
+  enable_nat_gateway      = true
+  vpc_cidr                = "10.20.30.0/24"
+  subnet_cidr_public      = ["10.20.30.0/27", "10.20.30.32/27", "10.20.30.64/27"]
+  subnet_cidr_private     = ["10.20.30.128/27", "10.20.30.160/27", "10.20.30.192/27"]
+  
 }
 ````
 ## Example Implementation

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,12 @@
 module "vpc" {
-  source = "github.com/kunduso/terraform-aws-vpc?ref=v1.0.1"
-  region = var.region
+  # source = "github.com/kunduso/terraform-aws-vpc?ref=v1.0.2"
+  source                  = "../"
+  region                  = var.region
+  enable_internet_gateway = true
+  enable_nat_gateway      = true
+  vpc_cidr                = "10.20.30.0/24"
+  subnet_cidr_public      = ["10.20.30.0/27", "10.20.30.32/27", "10.20.30.64/27"]
+  subnet_cidr_private     = ["10.20.30.128/27", "10.20.30.160/27", "10.20.30.192/27"]
   #CKV_TF_1: Ensure Terraform module sources use a commit hash
   #checkov:skip=CKV_TF_1: This is a self hosted module where the version number is tagged rather than the commit hash.
 }

--- a/flow_log.tf
+++ b/flow_log.tf
@@ -20,12 +20,10 @@ resource "aws_cloudwatch_log_group" "network_flow_logging" {
 data "aws_iam_policy_document" "assume_role" {
   statement {
     effect = "Allow"
-
     principals {
       type        = "Service"
       identifiers = ["vpc-flow-logs.amazonaws.com"]
     }
-
     actions = ["sts:AssumeRole"]
   }
 }
@@ -40,7 +38,6 @@ data "aws_iam_policy_document" "vpc_flow_log_policy_document" {
   count = var.enable_flow_log ? 1 : 0
   statement {
     effect = "Allow"
-
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",

--- a/flow_log_kms.tf
+++ b/flow_log_kms.tf
@@ -17,7 +17,7 @@ resource "aws_kms_key" "custom_kms_key" {
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
 resource "aws_kms_alias" "key" {
   count         = var.enable_flow_log ? 1 : 0
-  name          = "alias/${local.vpc_name}"
+  name          = "alias/${local.vpc_name}-encrypt-flow-log"
   target_key_id = aws_kms_key.custom_kms_key[0].id
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy

--- a/variable.tf
+++ b/variable.tf
@@ -4,16 +4,16 @@ variable "region" {
 }
 variable "vpc_cidr" {
   description = "CIDR for the VPC."
-  default     = "10.20.30.0/24"
+  default     = ""
 }
 variable "subnet_cidr_private" {
   description = "CIDR blocks for the private subnets."
-  default     = ["10.20.30.0/27", "10.20.30.32/27", "10.20.30.64/27", "10.20.30.96/27"]
+  default     = []
   type        = list(any)
 }
 variable "subnet_cidr_public" {
   description = "CIDR blocks for the public subnets."
-  default     = ["10.20.30.128/27", "10.20.30.160/27", "10.20.30.192/27", "10.20.30.224/27"]
+  default     = []
   type        = list(any)
 }
 variable "enable_dns_hostnames" {


### PR DESCRIPTION
The changes in this PR close #15 and close #16.
With these changes, now the calling module requires to pass additional information such as the `vpc_cidr`, `subnet_cidr_public`, and `subnet_cidr_private`. While the `vpc_cidr` is mandatory, the other variables are not.