### PR TITLE
Minor ReadMe fix

### DIFF
--- a/docs.yml
+++ b/docs.yml
@@ -4,7 +4,7 @@
 # version: ">= 0.10, < 0.12"
 
 # see: https://terraform-docs.io/user-guide/configuration/formatter
-formatter: markdown table
+formatter: markdown
 
 # see: https://terraform-docs.io/user-guide/configuration/header-from
 header-from: ./docs/header.md


### PR DESCRIPTION
The ReadMe was rendering the sections as `#### Requirements` while the other sections from the header and footer had the sections as `##`. This PR is to standardize both to `##`.