### PR TITLE
Fix tag precedence to allow user tags to override module-generated Name tags

### DIFF
--- a/flow_log.tf
+++ b/flow_log.tf
@@ -5,7 +5,7 @@ resource "aws_flow_log" "network_flow_logging" {
   log_destination = aws_cloudwatch_log_group.network_flow_logging[0].arn
   traffic_type    = "ALL"
   vpc_id          = aws_vpc.this.id
-  tags            = merge(var.tags, { "Name" = "${local.flow_log}" })
+  tags            = merge({ "Name" = "${local.flow_log}" }, var.tags)
 }
 
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_log_group" "network_flow_logging" {
   name              = local.flow_log
   retention_in_days = 365
   kms_key_id        = aws_kms_key.custom_kms_key[0].arn
-  tags              = merge(var.tags, { "Name" = "${local.flow_log}" })
+  tags              = merge({ "Name" = "${local.flow_log}" }, var.tags)
 }
 
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document
@@ -34,7 +34,7 @@ resource "aws_iam_role" "vpc_flow_log_role" {
   count              = var.enable_flow_log ? 1 : 0
   name               = "${local.vpc_name}-vpc-flow-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
-  tags               = merge(var.tags, { "Name" = "${local.vpc_name}-vpc-flow-role" })
+  tags               = merge({ "Name" = "${local.vpc_name}-vpc-flow-role" }, var.tags)
 }
 
 data "aws_iam_policy_document" "vpc_flow_log_policy_document" {

--- a/flow_log_kms.tf
+++ b/flow_log_kms.tf
@@ -14,7 +14,7 @@ resource "aws_kms_key" "custom_kms_key" {
   enable_key_rotation     = true
   #checkov:skip=CKV2_AWS_64: "Ensure KMS key Policy is defined"
   #KMS Key policy is defined as aws_kms_key_policy encrypt_log {}
-  tags = merge(var.tags, { Name = "${local.vpc_name}-encryption-key" })
+  tags = merge({ Name = "${local.vpc_name}-encryption-key" }, var.tags)
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
 resource "aws_kms_alias" "key" {

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_vpc" "this" {
   enable_dns_support = var.enable_dns_support == null ? false : var.enable_dns_support
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc#enable_dns_hostnames
   enable_dns_hostnames = var.enable_dns_hostnames == null ? false : var.enable_dns_hostnames
-  tags                 = merge(var.tags, { "Name" = local.vpc_name })
+  tags                 = merge({ "Name" = local.vpc_name }, var.tags)
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones
 data "aws_availability_zones" "available" {
@@ -21,7 +21,7 @@ resource "aws_subnet" "private" {
   vpc_id            = aws_vpc.this.id
   cidr_block        = var.subnet_cidr_private[count.index]
   availability_zone = data.aws_availability_zones.available.names[count.index % 3]
-  tags              = merge(var.tags, { "Name" = "${local.vpc_name}-private-${count.index + 1}" })
+  tags              = merge({ "Name" = "${local.vpc_name}-private-${count.index + 1}" }, var.tags)
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet
 resource "aws_subnet" "public" {
@@ -30,19 +30,19 @@ resource "aws_subnet" "public" {
   cidr_block              = var.subnet_cidr_public[count.index]
   availability_zone       = data.aws_availability_zones.available.names[count.index % 3]
   map_public_ip_on_launch = true
-  tags                    = merge(var.tags, { "Name" = "${local.vpc_name}-public-${count.index + 1}" })
+  tags                    = merge({ "Name" = "${local.vpc_name}-public-${count.index + 1}" }, var.tags)
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table
 resource "aws_route_table" "private" {
   count  = length(var.subnet_cidr_private) > 0 ? length(var.subnet_cidr_private) : 0
   vpc_id = aws_vpc.this.id
-  tags   = merge(var.tags, { "Name" = "${local.vpc_name}-private-${count.index + 1}" })
+  tags   = merge({ "Name" = "${local.vpc_name}-private-${count.index + 1}" }, var.tags)
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table
 resource "aws_route_table" "public" {
   count  = length(var.subnet_cidr_public) > 0 ? 1 : 0
   vpc_id = aws_vpc.this.id
-  tags   = merge(var.tags, { "Name" = "${local.vpc_name}-public" })
+  tags   = merge({ "Name" = "${local.vpc_name}-public" }, var.tags)
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association
 resource "aws_route_table_association" "private" {
@@ -60,7 +60,7 @@ resource "aws_route_table_association" "public" {
 resource "aws_internet_gateway" "this_igw" {
   count  = var.enable_internet_gateway && length(var.subnet_cidr_public) > 0 ? 1 : 0
   vpc_id = aws_vpc.this.id
-  tags   = merge(var.tags, { "Name" = "${local.vpc_name}-gateway" })
+  tags   = merge({ "Name" = "${local.vpc_name}-gateway" }, var.tags)
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route
 resource "aws_route" "internet_route" {
@@ -74,7 +74,7 @@ resource "aws_eip" "nat_gateway" {
   count  = (var.enable_nat_gateway && var.enable_internet_gateway && length(var.subnet_cidr_public) > 0) && (length(var.subnet_cidr_private) == length(var.subnet_cidr_public)) ? length(var.subnet_cidr_public) : 0
   domain = "vpc"
   #checkov:skip=CKV2_AWS_19: The IP is attached to the NAT gateway
-  tags = merge(var.tags, { "Name" = "${local.vpc_name}-nat-eip-${count.index + 1}" })
+  tags = merge({ "Name" = "${local.vpc_name}-nat-eip-${count.index + 1}" }, var.tags)
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway
 resource "aws_nat_gateway" "public" {
@@ -82,7 +82,7 @@ resource "aws_nat_gateway" "public" {
   subnet_id     = element(aws_subnet.public.*.id, count.index)
   allocation_id = aws_eip.nat_gateway[count.index].id
   depends_on    = [aws_internet_gateway.this_igw]
-  tags          = merge(var.tags, { "Name" = "${local.vpc_name}-nat-${count.index + 1}" })
+  tags          = merge({ "Name" = "${local.vpc_name}-nat-${count.index + 1}" }, var.tags)
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route
 resource "aws_route" "private_route" {

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,5 +1,5 @@
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group
 resource "aws_default_security_group" "default" {
   vpc_id = aws_vpc.this.id
-  tags   = merge(var.tags, { "Name" = "${local.vpc_name}-default" })
+  tags   = merge({ "Name" = "${local.vpc_name}-default" }, var.tags)
 }


### PR DESCRIPTION
This PR fixes the tag merging order across all resources in the module to allow user-provided tags to take precedence over module-generated Name tags. Closes #33 