### PR TITLE
Add support for subnet-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ This module provides foundation for setting up secure, isolated environments in 
 | <a name="input_enable_flow_log"></a> [enable_flow_log](#input_enable_flow_log) | Enable VPC flow logs | `bool` | `true` | no |
 | <a name="input_enable_internet_gateway"></a> [enable_internet_gateway](#input_enable_internet_gateway) | Enable internet gateway for VPC. | `bool` | `false` | no |
 | <a name="input_enable_nat_gateway"></a> [enable_nat_gateway](#input_enable_nat_gateway) | Enable nat gateway for VPC. | `bool` | `false` | no |
+| <a name="input_private_subnet_tags"></a> [private_subnet_tags](#input_private_subnet_tags) | Additional tags for private subnets | `map(string)` | `{}` | no |
+| <a name="input_public_subnet_tags"></a> [public_subnet_tags](#input_public_subnet_tags) | Additional tags for public subnets | `map(string)` | `{}` | no |
 | <a name="input_subnet_cidr_private"></a> [subnet_cidr_private](#input_subnet_cidr_private) | CIDR blocks for the private subnets. | `list(any)` | `[]` | no |
 | <a name="input_subnet_cidr_public"></a> [subnet_cidr_public](#input_subnet_cidr_public) | CIDR blocks for the public subnets. | `list(any)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input_tags) | AWS Cloud resource tags. | `map(string)` | <pre>{<br/>  "Module": "https://github.com/kunduso/terraform-aws-vpc"<br/>}</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_subnet" "private" {
   vpc_id            = aws_vpc.this.id
   cidr_block        = var.subnet_cidr_private[count.index]
   availability_zone = data.aws_availability_zones.available.names[count.index % min(3, length(data.aws_availability_zones.available.names))]
-  tags              = merge({ "Name" = "${local.vpc_name}-private-${count.index + 1}" }, var.tags)
+  tags              = merge({ "Name" = "${local.vpc_name}-private-${count.index + 1}" }, var.tags, var.private_subnet_tags)
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet
 resource "aws_subnet" "public" {
@@ -30,7 +30,7 @@ resource "aws_subnet" "public" {
   cidr_block              = var.subnet_cidr_public[count.index]
   availability_zone       = data.aws_availability_zones.available.names[count.index % min(3, length(data.aws_availability_zones.available.names))]
   map_public_ip_on_launch = true
-  tags                    = merge({ "Name" = "${local.vpc_name}-public-${count.index + 1}" }, var.tags)
+  tags                    = merge({ "Name" = "${local.vpc_name}-public-${count.index + 1}" }, var.tags, var.public_subnet_tags)
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table
 resource "aws_route_table" "private" {

--- a/tests/vpc_subnet_tags.tftest.hcl
+++ b/tests/vpc_subnet_tags.tftest.hcl
@@ -4,7 +4,7 @@ provider "aws" {
 
 # Test subnet-specific tags functionality
 run "test_subnet_specific_tags" {
-  command = plan
+  command = apply
 
   variables {
     vpc_cidr            = "10.0.0.0/16"

--- a/tests/vpc_subnet_tags.tftest.hcl
+++ b/tests/vpc_subnet_tags.tftest.hcl
@@ -1,0 +1,131 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+# Test subnet-specific tags functionality
+run "test_subnet_specific_tags" {
+  command = plan
+
+  variables {
+    vpc_cidr            = "10.0.0.0/16"
+    region              = "us-east-1"
+    subnet_cidr_private = ["10.0.1.0/24", "10.0.2.0/24"]
+    subnet_cidr_public  = ["10.0.11.0/24", "10.0.12.0/24"]
+
+    # EKS-specific tags as mentioned in the issue
+    public_subnet_tags = {
+      "kubernetes.io/role/elb" = "1"
+      "Environment"            = "test-public"
+    }
+
+    private_subnet_tags = {
+      "kubernetes.io/role/internal-elb" = "1"
+      "Environment"                     = "test-private"
+    }
+
+    tags = {
+      "Project" = "vpc-module-test"
+    }
+  }
+
+  assert {
+    condition     = length(aws_subnet.private) == 2
+    error_message = "Should create exactly 2 private subnets"
+  }
+
+  assert {
+    condition     = length(aws_subnet.public) == 2
+    error_message = "Should create exactly 2 public subnets"
+  }
+
+  # Test that private subnets have the correct tags
+  assert {
+    condition     = alltrue([for subnet in aws_subnet.private : subnet.tags["kubernetes.io/role/internal-elb"] == "1"])
+    error_message = "All private subnets should have kubernetes.io/role/internal-elb tag"
+  }
+
+  assert {
+    condition     = alltrue([for subnet in aws_subnet.private : subnet.tags["Environment"] == "test-private"])
+    error_message = "All private subnets should have Environment=test-private tag"
+  }
+
+  # Test that public subnets have the correct tags
+  assert {
+    condition     = alltrue([for subnet in aws_subnet.public : subnet.tags["kubernetes.io/role/elb"] == "1"])
+    error_message = "All public subnets should have kubernetes.io/role/elb tag"
+  }
+
+  assert {
+    condition     = alltrue([for subnet in aws_subnet.public : subnet.tags["Environment"] == "test-public"])
+    error_message = "All public subnets should have Environment=test-public tag"
+  }
+
+  # Test that global tags are still applied
+  assert {
+    condition     = alltrue([for subnet in aws_subnet.private : subnet.tags["Project"] == "vpc-module-test"])
+    error_message = "All private subnets should have global Project tag"
+  }
+
+  assert {
+    condition     = alltrue([for subnet in aws_subnet.public : subnet.tags["Project"] == "vpc-module-test"])
+    error_message = "All public subnets should have global Project tag"
+  }
+
+  # Test that Name tags are still generated correctly
+  assert {
+    condition     = alltrue([for i, subnet in aws_subnet.private : contains(keys(subnet.tags), "Name")])
+    error_message = "All private subnets should have Name tags"
+  }
+
+  assert {
+    condition     = alltrue([for i, subnet in aws_subnet.public : contains(keys(subnet.tags), "Name")])
+    error_message = "All public subnets should have Name tags"
+  }
+}
+
+# Test backward compatibility - no subnet-specific tags provided
+run "test_backward_compatibility" {
+  command = plan
+
+  variables {
+    vpc_cidr            = "10.1.0.0/16"
+    region              = "us-east-1"
+    subnet_cidr_private = ["10.1.1.0/24"]
+    subnet_cidr_public  = ["10.1.11.0/24"]
+
+    tags = {
+      "Project" = "backward-compatibility-test"
+    }
+  }
+
+  assert {
+    condition     = length(aws_subnet.private) == 1
+    error_message = "Should create exactly 1 private subnet"
+  }
+
+  assert {
+    condition     = length(aws_subnet.public) == 1
+    error_message = "Should create exactly 1 public subnet"
+  }
+
+  # Test that subnets still get global tags and Name tags
+  assert {
+    condition     = aws_subnet.private[0].tags["Project"] == "backward-compatibility-test"
+    error_message = "Private subnet should have global Project tag"
+  }
+
+  assert {
+    condition     = aws_subnet.public[0].tags["Project"] == "backward-compatibility-test"
+    error_message = "Public subnet should have global Project tag"
+  }
+
+  assert {
+    condition     = contains(keys(aws_subnet.private[0].tags), "Name")
+    error_message = "Private subnet should have Name tag"
+  }
+
+  assert {
+    condition     = contains(keys(aws_subnet.public[0].tags), "Name")
+    error_message = "Public subnet should have Name tag"
+  }
+}

--- a/variable.tf
+++ b/variable.tf
@@ -102,3 +102,15 @@ variable "enable_flow_log" {
   type        = bool
   default     = true
 }
+
+variable "public_subnet_tags" {
+  description = "Additional tags for public subnets"
+  type        = map(string)
+  default     = {}
+}
+
+variable "private_subnet_tags" {
+  description = "Additional tags for private subnets"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
This PR adds support for subnet-specific tags to enable flexible tagging strategies for public and private subnets, addressing the need for EKS integration and other use cases.

## Changes Made

### 🏷️ New Variables
- **Added `public_subnet_tags`** - Additional tags for public subnets
- **Added `private_subnet_tags`** - Additional tags for private subnets
- Both variables default to `{}` for backward compatibility

### 🔧 Updated Resources
- **Modified `aws_subnet.private`** - Tags now merge: Name + global tags + private_subnet_tags
- **Modified `aws_subnet.public`** - Tags now merge: Name + global tags + public_subnet_tags

### 🧪 Test Coverage
- **Added `tests/vpc_subnet_tags.tftest.hcl`** with comprehensive test scenarios:
  - EKS-specific tags validation (`kubernetes.io/role/elb`, `kubernetes.io/role/internal-elb`)
  - Backward compatibility testing
  - Tag merging validation
  - Name tag preservation

## Use Cases

### EKS Integration
```hcl
module "vpc" {
  source = "kunduso/vpc/aws"
  
  public_subnet_tags = {
    "kubernetes.io/role/elb" = "1"
  }
  
  private_subnet_tags = {
    "kubernetes.io/role/internal-elb" = "1"
  }
}
```

### Cost Allocation
```hcl
public_subnet_tags = {
  "CostCenter" = "web-tier"
  "Tier"       = "public"
}

private_subnet_tags = {
  "CostCenter" = "app-tier"
  "Tier"       = "private"
}
```

## Benefits
- ✅ **Backward Compatible** - No breaking changes
- ✅ **Flexible** - Supports any tags, not service-specific
- ✅ **Well Tested** - Comprehensive test coverage
- ✅ **Follows Best Practices** - Proper tag merging order

## Test Results
All tests pass, including existing functionality and new subnet-specific tag features.

Closes #42